### PR TITLE
Feat: 버튼 컴포넌트 폰트 굵기 추가

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -180,7 +180,7 @@ export default function Button({
           ? fontWeight
           : fontWeight
             ? theme.fontWeight[fontWeight as keyof typeof theme.fontWeight]
-            : undefined
+            : theme.fontWeight.medium
       }
       $transition={transition || style.transition || 'all 0.3s ease'}
       $hoverColor={hoverColor || style.hoverColor}

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -17,6 +17,7 @@ const variantStyles: Record<
     padding: string;
     boxShadow: string;
     size: keyof typeof theme.fontSize;
+    fontWeight?: keyof typeof theme.fontWeight | number;
     transition?: string;
     hoverColor?: keyof typeof theme.colors;
     disabledColor: keyof typeof theme.colors;
@@ -31,6 +32,7 @@ const variantStyles: Record<
     padding: '20px 72px',
     boxShadow: '0px 0px 10px rgba(79, 99, 255, 0.4)',
     size: 'xl',
+    fontWeight: 'bold',
     transition: 'all 0.3s ease',
     hoverColor: 'primary',
     disabledColor: 'gray400',
@@ -44,6 +46,7 @@ const variantStyles: Record<
     padding: '16px 24px',
     boxShadow: 'none',
     size: 'm',
+    fontWeight: 'medium',
     disabledColor: 'gray400',
   },
   link: {
@@ -55,6 +58,7 @@ const variantStyles: Record<
     padding: '16px 24px',
     boxShadow: 'none',
     size: 'lg',
+    fontWeight: 'medium',
     disabledColor: 'gray400',
   },
   job: {
@@ -66,6 +70,7 @@ const variantStyles: Record<
     padding: '12px 16px',
     boxShadow: '4px 4px 4px rgba(79, 99, 255, 0.4)',
     size: 'm',
+    fontWeight: 'medium',
     transition: 'all 0.3s ease',
     hoverColor: 'primary',
     disabledColor: 'gray300',
@@ -85,6 +90,7 @@ type ButtonProps = {
   padding?: string;
   boxShadow?: string;
   size?: keyof typeof theme.fontSize | string;
+  fontWeight?: keyof typeof theme.fontWeight | number;
   transition?: string;
   hoverColor?: keyof typeof theme.colors | string;
   disabledColor?: keyof typeof theme.colors | string;
@@ -99,6 +105,7 @@ const ButtonStyle = styled.button<{
   $border: string;
   $boxShadow: string;
   $fontSize: string;
+  $fontWeight: number;
   $transition: string;
   $hoverColor?: string;
   $disabledColor: string;
@@ -116,6 +123,7 @@ const ButtonStyle = styled.button<{
   border-radius: 100px;
   box-shadow: ${({ $boxShadow }) => $boxShadow};
   font-size: ${({ $fontSize }) => $fontSize};
+  font-weight: ${({ $fontWeight }) => $fontWeight};
   transition: ${({ $transition }) => $transition};
 
   &:hover:enabled {
@@ -148,6 +156,7 @@ export default function Button({
   border,
   boxShadow,
   size,
+  fontWeight,
   transition,
   hoverColor,
   disabledColor,
@@ -166,6 +175,13 @@ export default function Button({
       $border={border || style.border}
       $boxShadow={boxShadow || style.boxShadow}
       $fontSize={theme.fontSize[(size || style.size) as keyof typeof theme.fontSize]}
+      $fontWeight={
+        typeof fontWeight === 'number'
+          ? fontWeight
+          : fontWeight
+            ? theme.fontWeight[fontWeight as keyof typeof theme.fontWeight]
+            : undefined
+      }
       $transition={transition || style.transition || 'all 0.3s ease'}
       $hoverColor={hoverColor || style.hoverColor}
       $disabledColor={disabledColor || style.disabledColor}


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 버튼 컴포넌트에 누락된 fontWeight 속성을 추가하였습니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- variantStyles에 fontWeight 값을 추가하여 버튼 타입별 기본 폰트 두께를 지정할 수 있게 했습니다.
- props로 전달 시 숫자(fontWeight={700}) 또는 theme 키(fontWeight="bold") 모두 지원하도록 처리했습니다.
- fontWeight가 전달되지 않는 경우 별도의 기본값을 주지 않고, 스타일 컴포넌트가 브라우저 기본값을 따르도록 했습니다.
- theme 기반 색상/폰트 사용과 유사한 구조로 통일성을 유지했습니다.

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- variant 지정 시 의도한 fontWeight가 적용되는지 확인 부탁드립니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
