### PR TITLE
Feat: 직업 가치관 검사 페이지 커리어넷 api 연동

### DIFF
--- a/client/src/api/questions.ts
+++ b/client/src/api/questions.ts
@@ -1,0 +1,18 @@
+export interface Question {
+  qitemNo: number;
+  question: string;
+  answer01: string;
+  answer02: string;
+  answer03: string;
+  answer04: string;
+  answerScore01: string;
+  answerScore02: string;
+}
+
+export const fetchQuestions = async (): Promise<Question[]> => {
+  const res = await fetch('/api/questions');
+  if (!res.ok) {
+    throw new Error('질문지를 불러오지 못했습니다');
+  }
+  return res.json(); // 커리어넷 API의 실제 질문 목록을 반환
+};

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -25,7 +25,7 @@ const iconMap: Record<string, string> = {
   보수: pay,
   자기계발: selfDevelopment,
   사회봉사: socialContribution,
-  사회의인정: socialRecognition,
+  '사회적 인정': socialRecognition, //사회의인정 -> 사회적인정: 커리어넷 api대로 수정
   안정성: stability,
 };
 

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -15,6 +15,7 @@ type Props = {
   onClick?: () => void;
   width?: string;
   height?: string;
+  description?: string;
 };
 
 // 텍스트 값과 아이콘을 매핑하는 객체
@@ -62,13 +63,14 @@ const CardWrapper = styled.div<{
 
 // 아이콘 스타일
 const CardIcon = styled.img`
-  width: 70%;
-  height: 70%;
-  margin-bottom: 0.5rem;
+  margin-top: -18px;
+  width: 65%;
+  height: 65%;
 `;
 
 // 텍스트 스타일
 const CardLabel = styled.span`
+  margin-top: -10px;
   font-size: ${({ theme }) => theme.fontSize.lg};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   color: ${({ theme }) => theme.colors.black};
@@ -81,12 +83,22 @@ const InfoCardLabel = styled.span`
   color: ${({ theme }) => theme.colors.black};
 `;
 
+// 가치 설명 텍스트용 스타일
+const CardDescription = styled.span`
+  max-width: 180px;
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: ${({ theme }) => theme.colors.gray700};
+  text-align: center;
+  margin-top: 0.25rem;
+  line-height: 1.4;
+`;
+
 // ================= Card Component =================
 /**
  * 개별 가치(선택지)를 카드 형태로 시각화하는 컴포넌트
  * 선택 여부에 따라 스타일이 달라지고, 클릭 시 상위에서 전달된 콜백을 실행함
  */
-export default function Card({ value, selected, onClick, width, height }: Props) {
+export default function Card({ value, selected, onClick, width, height, description }: Props) {
   // value에 해당하는 아이콘 불러오기
   const icon = iconMap[value];
 
@@ -101,6 +113,7 @@ export default function Card({ value, selected, onClick, width, height }: Props)
     >
       <CardIcon src={icon} alt={`${value} 아이콘`} />
       <CardLabel>{value}</CardLabel>
+      {description && <CardDescription>{description}</CardDescription>}
     </CardWrapper>
   );
 }

--- a/client/src/components/Loading.tsx
+++ b/client/src/components/Loading.tsx
@@ -1,0 +1,37 @@
+import styled, { keyframes } from 'styled-components';
+import Text from './Text';
+
+export default function Loading({ message = '문항을 불러오는 중이에요...' }: { message?: string }) {
+  return (
+    <LoadingContainer>
+      <Spinner />
+      <Text as="p" size="m" weight="medium" color="gray700">
+        {message}
+      </Text>
+    </LoadingContainer>
+  );
+}
+
+// 스타일 정의
+const LoadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 60vh;
+  gap: 1.5rem;
+`;
+
+const rotate = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+const Spinner = styled.div`
+  width: 48px;
+  height: 48px;
+  border: 5px solid ${({ theme }) => theme.colors.gray300};
+  border-top: 5px solid ${({ theme }) => theme.colors.primary};
+  border-radius: 50%;
+  animation: ${rotate} 1s linear infinite;
+`;

--- a/client/src/features/test/TestInformSection.tsx
+++ b/client/src/features/test/TestInformSection.tsx
@@ -111,10 +111,8 @@ const renderCardContent = () => (
       <TextWrapper>
         <Text as="h2" size="ml" weight="bold" color="black" align="center">
           직업과 관련된 다양한 욕구 및 가치들에 대해 여러분이 상대적으로 무엇을 얼마나 더 중요하게
-          여기는가를 살펴보고,
-        </Text>
-        <Text as="h2" size="ml" weight="bold" color="black" align="center">
-          그 가치가 충족될 가능성이 높은 직업을 탐색할 수 있도록 도움을 주는 검사입니다.
+          여기는가를 살펴보고, 그 가치가 충족될 가능성이 높은 직업을 탐색할 수 있도록 도움을 주는
+          검사입니다.
         </Text>
       </TextWrapper>
 

--- a/client/src/features/test/TestInformSection.tsx
+++ b/client/src/features/test/TestInformSection.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled.div`
 const MotionSection = motion(Wrapper);
 
 const CardContent = styled.div`
-  max-width: 85%;
+  max-width: 90%;
 `;
 
 // 검사 설명/예시 묶음
@@ -46,6 +46,7 @@ const InfoBlock = styled.div`
   gap: 28px; // 제목과 아래 요소 간격
   padding-top: 20px;
   padding-bottom: 10px;
+  max-width: 850px;
 `;
 
 // 검사 진행방법, 설명 텍스트, 샘플 묶음

--- a/client/src/features/test/TestQuestionSection.tsx
+++ b/client/src/features/test/TestQuestionSection.tsx
@@ -144,11 +144,13 @@ export default function TestQuestionSection({ currentIndex, onAnswer }: Props) {
             value={left}
             selected={selected === left}
             onClick={() => setSelected(left)}
+            description={questions[index].answer03} // ✅ 선택지 설명 1번
           />
           <ResponsiveCard
             value={right}
             selected={selected === right}
             onClick={() => setSelected(right)}
+            description={questions[index].answer04} // ✅ 선택지 설명 2번
           />
         </CardContainer>
 

--- a/client/src/features/test/TestQuestionSection.tsx
+++ b/client/src/features/test/TestQuestionSection.tsx
@@ -1,12 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
+
 import FullScreenSection from '../../components/FullScreenSection';
 import Card from '../../components/Card';
 import Button from '../../components/Button';
 import Text from '../../components/Text';
 import CardFrame from '../../components/CardFrame';
-import testData from '../../data/testData';
+
+import { fetchQuestions } from '../../api/questions';
+import type { Question } from '../../api/questions';
 
 // ============ Props Type ============
 type Props = {
@@ -24,7 +27,6 @@ const Wrapper = styled.div`
   justify-content: center;
 `;
 
-// ✅ Motion 적용한 Wrapper
 const MotionWrapper = motion(Wrapper);
 
 const CardContainer = styled.div`
@@ -61,6 +63,25 @@ const ResponsiveButton = styled(Button)`
 export default function TestQuestionSection({ currentIndex, onAnswer }: Props) {
   const [selected, setSelected] = useState<string | null>(null);
   const [step, setStep] = useState(0);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // 질문 데이터 fetch
+  useEffect(() => {
+    const loadQuestions = async () => {
+      try {
+        const data = await fetchQuestions();
+        setQuestions(data);
+      } catch (err) {
+        console.error(err);
+        alert('질문지를 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadQuestions();
+  }, []);
 
   useEffect(() => {
     setSelected(null); // 질문이 바뀌면 선택 초기화
@@ -75,10 +96,10 @@ export default function TestQuestionSection({ currentIndex, onAnswer }: Props) {
   };
 
   const renderQuestion = (index: number) => {
-    const data = testData[index];
+    const data = questions[index];
     if (!data) return null;
 
-    const { left, right } = data;
+    const { answer01: left, answer02: right } = data;
 
     return (
       <div
@@ -145,19 +166,25 @@ export default function TestQuestionSection({ currentIndex, onAnswer }: Props) {
 
   return (
     <FullScreenSection>
-      <MotionWrapper
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -20 }}
-        transition={{ duration: 0.5, ease: 'easeOut' }}
-      >
-        <CardFrame
-          step={step}
-          topContent={renderQuestion(currentIndex)}
-          middleContent={renderQuestion(currentIndex + 1)}
-          backContent={renderQuestion(currentIndex + 2)}
-        />
-      </MotionWrapper>
+      {loading ? (
+        <Text as="p" size="m" weight="medium" color="gray700">
+          질문지를 불러오는 중입니다...
+        </Text>
+      ) : (
+        <MotionWrapper
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          transition={{ duration: 0.5, ease: 'easeOut' }}
+        >
+          <CardFrame
+            step={step}
+            topContent={renderQuestion(currentIndex)}
+            middleContent={renderQuestion(currentIndex + 1)}
+            backContent={renderQuestion(currentIndex + 2)}
+          />
+        </MotionWrapper>
+      )}
     </FullScreenSection>
   );
 }

--- a/client/src/features/test/TestQuestionSection.tsx
+++ b/client/src/features/test/TestQuestionSection.tsx
@@ -10,6 +10,7 @@ import CardFrame from '../../components/CardFrame';
 
 import { fetchQuestions } from '../../api/questions';
 import type { Question } from '../../api/questions';
+import Loading from '../../components/Loading';
 
 // ============ Props Type ============
 type Props = {
@@ -169,9 +170,7 @@ export default function TestQuestionSection({ currentIndex, onAnswer }: Props) {
   return (
     <FullScreenSection>
       {loading ? (
-        <Text as="p" size="m" weight="medium" color="gray700">
-          질문지를 불러오는 중입니다...
-        </Text>
+        <Loading message="당신에게 맞는 질문을 준비 중이에요..." />
       ) : (
         <MotionWrapper
           initial={{ opacity: 0, y: 20 }}

--- a/client/src/pages/TestPage.tsx
+++ b/client/src/pages/TestPage.tsx
@@ -6,6 +6,7 @@ import TestCompleteSection from '../features/test/TestCompleteSection';
 
 import { fetchQuestions } from '../api/questions';
 import type { Question } from '../api/questions';
+import Loading from '../components/Loading';
 
 import Image from '../components/Image';
 import cubeIcon from '../assets/icons/icon-cube.png';
@@ -81,7 +82,7 @@ export default function TestPage() {
 
       {/* 본문 콘텐츠 */}
       {loading ? (
-        <p style={{ textAlign: 'center', marginTop: '30vh' }}>문항을 불러오는 중입니다...</p>
+        <Loading message="당신에게 맞는 질문을 준비 중이에요..." />
       ) : currentIndex === 0 ? (
         <TestInformSection onStart={() => setCurrentIndex(1)} />
       ) : !isComplete ? (

--- a/client/src/pages/TestPage.tsx
+++ b/client/src/pages/TestPage.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import TestInformSection from '../features/test/TestInformSection';
 import TestQuestionSection from '../features/test/TestQuestionSection';
 import TestCompleteSection from '../features/test/TestCompleteSection';
-import testData from '../data/testData';
+
+import { fetchQuestions } from '../api/questions';
+import type { Question } from '../api/questions';
+
 import Image from '../components/Image';
 import cubeIcon from '../assets/icons/icon-cube.png';
 import ringIcon from '../assets/icons/icon-ring.png';
@@ -28,8 +31,21 @@ const BackgroundFloatWrapper = styled.div`
 export default function TestPage() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [answers, setAnswers] = useState<string[]>([]);
+  const [questions, setQuestions] = useState<Question[]>([]); // ✅ 실제 질문
+  const [loading, setLoading] = useState(true);
 
-  const isComplete = currentIndex > testData.length;
+  // ✅ API로 질문 불러오기
+  useEffect(() => {
+    fetchQuestions()
+      .then((data) => setQuestions(data))
+      .catch((err) => {
+        console.error(err);
+        alert('질문 데이터를 불러올 수 없습니다.');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const isComplete = currentIndex > questions.length;
 
   const handleAnswer = (value: string) => {
     setAnswers((prev) => [...prev, value]);
@@ -64,11 +80,15 @@ export default function TestPage() {
       </BackgroundFloatWrapper>
 
       {/* 본문 콘텐츠 */}
-      {currentIndex === 0 && <TestInformSection onStart={() => setCurrentIndex(1)} />}
-      {!isComplete && currentIndex > 0 && (
+      {loading ? (
+        <p style={{ textAlign: 'center', marginTop: '30vh' }}>문항을 불러오는 중입니다...</p>
+      ) : currentIndex === 0 ? (
+        <TestInformSection onStart={() => setCurrentIndex(1)} />
+      ) : !isComplete ? (
         <TestQuestionSection currentIndex={currentIndex - 1} onAnswer={handleAnswer} />
+      ) : (
+        <TestCompleteSection answers={answers} />
       )}
-      {isComplete && <TestCompleteSection answers={answers} />}
     </div>
   );
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,14 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      // 클라이언트에서 /api/questions로 요청 → 서버의 http://localhost:3000/questions로 전달
+      '/api': {
+        target: 'http://localhost:3000', // 🔁 Express 서버가 여기서 실행 중이어야 함
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2634,7 +2634,7 @@ snapshots:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2713,7 +2713,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2816,7 +2816,7 @@ snapshots:
   '@eslint/config-array@0.20.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2830,7 +2830,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3209,7 +3209,7 @@ snapshots:
       '@typescript-eslint/types': 8.32.0
       '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.32.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       eslint: 9.26.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -3224,7 +3224,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.32.0(eslint@9.26.0)(typescript@5.8.3)
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       eslint: 9.26.0
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -3237,7 +3237,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.32.0
       '@typescript-eslint/visitor-keys': 8.32.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -3427,7 +3427,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -3674,10 +3674,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.0(supports-color@5.5.0):
     dependencies:
@@ -4000,7 +3996,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -4063,7 +4059,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -4137,7 +4133,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -4944,7 +4940,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -4987,7 +4983,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 커리어넷 질문 API연결을 위한 세팅을 했습니다.  --> vite.config.ts에 문장 추가
2. 가치관 아이콘을 불러오는 과정에서 커리어넷 API와 데이터명이 달라서 불러오지 못하는 오류를 해결했습니다.
3. TestQuestionSection의 TestData로 받아오던 데이터를 API를 연동하여 28개의 문항을 받아오도록 했습니다.
4. 가치관별 설명 script를 아이콘 아래에 배치되도록 api로 연결했습니다. 이때 아이콘 크기를 좀 더 줄이고 위로 올렸습니다.
5. TestInform에 가치관 검사 설명 Text가 불필요하게 두개의 컴포넌트로 나뉘어져있어서 하나로 합쳤습니다.
6. 로딩 스피너 컴포넌트 메인 컨셉과 유사하게 제작했습니다.
7. 문항 불러오는 과정에 모두 로딩 스피너를 적용했습니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 변경 사항이 곧 세부 설명....

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- TestData는 삭제하지 말아주세요! TestInform페이지에서 고정 데이터로 쓸 수 있게 필요합니다!
- 서버, 클라이언트 측 모두 pnpm dev하셔서 확인하시면 됩니다!
- 로딩 스피너 컴포넌트는 다른데서도 재활용할 수 있도록 제작했으니, message props 수정하여 사용하시면 될 것 같습니다.
- 로딩 스피너 불필요한 것 같거나 디자인이 어색하다면 리뷰 남겨주세요!
- 가치관별 설명 스크립트를 아이콘 아래에 배치했습니다. 레이아웃이 어색하지 않은지 확인해주세요!
- 사용자의 설문결과를 store 저장하게 하는 건 아직 진행 안 했습니다!

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![Animation5](https://github.com/user-attachments/assets/8b225012-32d5-4f81-a3bf-5d187d124fee)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
