### PR TITLE
Design 검사 결과 페이지 레이아웃 조정

### DIFF
--- a/client/src/features/result/ResultChart.tsx
+++ b/client/src/features/result/ResultChart.tsx
@@ -16,10 +16,10 @@ type ResultChartProps = {
 
 const Wrapper = styled.div`
   position: relative;
-  width: 50vw;
+  width: clamp(250px, 40vw, 700px);
   max-width: 450px;
   aspect-ratio: 1 / 1;
-  margin: 70px;
+  margin: 50px;
   border-radius: 1px solid red;
   .nivo-radar .grid text {
     display: none;

--- a/client/src/features/result/ResultChart.tsx
+++ b/client/src/features/result/ResultChart.tsx
@@ -32,7 +32,8 @@ const Label = styled.div<{ x: number; y: number; $active: boolean }>`
   left: ${({ x }) => x}%;
   top: ${({ y }) => y}%;
   cursor: pointer;
-  font-size: ${({ $active }) => ($active ? theme.fontSize.ml : theme.fontSize.m)};
+  font-size: ${({ $active }) =>
+    $active ? `clamp(14px, 2vw, ${theme.fontSize.ml})` : `clamp(12px, 1.8vw, ${theme.fontSize.m})`};
   color: ${({ $active }) => ($active ? theme.colors.primary : theme.colors.gray900)};
   font-weight: ${({ $active }) => ($active ? theme.fontWeight.bold : theme.fontWeight.medium)};
   white-space: nowrap;

--- a/client/src/features/result/ResultChart.tsx
+++ b/client/src/features/result/ResultChart.tsx
@@ -16,7 +16,7 @@ type ResultChartProps = {
 
 const Wrapper = styled.div`
   position: relative;
-  width: clamp(250px, 40vw, 700px);
+  width: clamp(250px, 50vw, 700px);
   max-width: 450px;
   aspect-ratio: 1 / 1;
   margin: 50px;

--- a/client/src/features/result/ResultDescriptionCard.tsx
+++ b/client/src/features/result/ResultDescriptionCard.tsx
@@ -5,19 +5,27 @@ import { theme } from '../../styles/theme';
 
 const Card = styled.div`
   position: relative;
-  width: clamp(200px, 42vw, 500px);
+  width: clamp(200px, 40vw, 500px);
   min-height: clamp(300px, 50vw, 400px);
   display: flex;
   flex-direction: column;
   background: #f9fbff;
   border-radius: 16px;
-  padding: clamp(5px, 1vw, 10px) clamp(20px, 3vw, 30px) clamp(5px, 1vw, 10px) clamp(15px, 2vw, 24px);
+  padding: 16px 24px;
   box-shadow:
     inset 10px 10px 10px 4px rgba(255, 255, 255, 0.6),
     inset -5px -5px 15px 4px rgba(193, 215, 249, 1);
 
   & p {
     padding-left: clamp(8px, 1vw, 10px);
+  }
+  @media (max-width: 768px) {
+    width: 80vw;
+    min-height: 400px;
+  }
+  @media (max-width: 485px) {
+    width: 80vw;
+    min-height: 300px;
   }
 `;
 

--- a/client/src/features/result/ResultDescriptionCard.tsx
+++ b/client/src/features/result/ResultDescriptionCard.tsx
@@ -5,19 +5,19 @@ import { theme } from '../../styles/theme';
 
 const Card = styled.div`
   position: relative;
-  width: clamp(200px, 40vw, 500px);
-  min-height: 300px;
+  width: clamp(200px, 42vw, 500px);
+  min-height: clamp(300px, 50vw, 400px);
   display: flex;
   flex-direction: column;
   background: #f9fbff;
   border-radius: 16px;
-  padding: 5px 30px 5px 24px;
+  padding: clamp(5px, 1vw, 10px) clamp(20px, 3vw, 30px) clamp(5px, 1vw, 10px) clamp(15px, 2vw, 24px);
   box-shadow:
     inset 10px 10px 10px 4px rgba(255, 255, 255, 0.6),
     inset -5px -5px 15px 4px rgba(193, 215, 249, 1);
 
   & p {
-    padding-left: 10px;
+    padding-left: clamp(8px, 1vw, 10px);
   }
 `;
 
@@ -32,18 +32,18 @@ const CloseButton = styled.button`
 }`;
 
 const SectionTitle = styled.h3`
-  width: 100px;
+  width: clamp(80px, 20vw, 100px);
   background-color: white;
   border-radius: 100px;
   box-shadow: 0px 1px 3px rgba(79, 99, 255, 0.5);
-  padding: 5px 0px;
+  padding: clamp(3px, 0.8vw, 5px) clamp(8px, 1vw, 12px);
   text-align: center;
-  font-size: ${theme.fontSize.m};
+  font-size: clamp(12px, 2vw, ${theme.fontSize.m});
 `;
 
 const SectionContent = styled.p`
-  font-size: ${theme.fontSize.m};
-  line-height: 28px;
+  font-size: clamp(12px, 2vw, ${theme.fontSize.m});
+  line-height: clamp(18px, 4vw, 28px);
 `;
 
 type ResultDescriptionCardProps = {

--- a/client/src/pages/ResultPage.tsx
+++ b/client/src/pages/ResultPage.tsx
@@ -56,6 +56,7 @@ const ResultSection = styled.div`
 `;
 
 const ResultTopWrapper = styled.div`
+  position: relative;
   display: flex;
   flex-wrap: wrap;
   gap: 2vw;

--- a/client/src/pages/ResultPage.tsx
+++ b/client/src/pages/ResultPage.tsx
@@ -58,13 +58,24 @@ const ResultSection = styled.div`
 const ResultTopWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 3rem;
+  gap: 2vw;
   justify-content: center;
   align-items: center;
-  margin-top: -70px;
-  > * {
-    flex: 1 1 300px; /* 최소 300px까지 줄어듦 */
-    max-width: 600px; /* (선택) 너무 커지지 않게 제한 */
+  margin-top: -30px;
+  min-height: clamp(400px, 60vw, 500px);
+`;
+
+const DescriptionWrapper = styled(motion.div)`
+  @media (max-width: 768px) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 `;
 
@@ -110,7 +121,7 @@ export default function ResultPage() {
           />
         </motion.div>
         {selectedLabel && (
-          <motion.div
+          <DescriptionWrapper
             key="description"
             variants={slideInVariants}
             initial="hidden"
@@ -118,7 +129,7 @@ export default function ResultPage() {
             exit="exit"
           >
             <ResultDescriptionCard label={selectedLabel} onClose={() => setSelectedLabel(null)} />
-          </motion.div>
+          </DescriptionWrapper>
         )}
       </ResultTopWrapper>
       <JobGroupSection />


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 차트 라벨 사이즈를 반응형으로 개선하였습니다.
2. 1024px 이상에서 차트-카드 wrap 현상을 제거하였습니다.
3. 모바일(768px 이하) DescriptionWrapper 화면 전체 덮어 차트 위로 카드가 나오도록 하였습니다.
4. 768px, 485px 카드 너비 및 최대 높이를 지정하였습니다.
5. 카드 부모 요소에 position: relative 누락된 부분을 추가하였습니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 1024px 이상에서는 clamp()를 활용해 차트와 카드가 wrap되지 않도록 너비를 유동적으로 개선하여 레이아웃을 안정화하였습니다.
- 768px 이하에서는 DescriptionWrapper가 position: absolute, width: 100%, height: 100%를 사용하여 모바일 전용 오버레이 레이어로 정상 동작하도록 수정했습니다.
- 768px, 485px 기준에서 카드의 너비 및 최대 높이를 별도 지정하여 모바일에서도 카드가 지나치게 작거나 커지지 않도록 개선했습니다.
- 카드의 부모(ResultTopWrapper)에 position: relative 누락 부분을 추가하여 DescriptionWrapper가 정확히 부모 기준으로 덮도록 구조를 안정화하였습니다.

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 모바일 및 태블릿, PC 환경에서 차트와 카드가 정상적으로 표시되는지 리뷰 부탁드립니다.
- 특히 768px 이하에서 DescriptionWrapper가 화면 전체를 정상 덮고 차트-카드가 뒤에 가려지는지 체크 부탁드립니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

### 화면 사이즈: 768px 이하

![Animation](https://github.com/user-attachments/assets/d01c6e50-e46a-4b59-b605-e7a87011a148)

### 화면 사이즈: 485px 이하

![Animation1](https://github.com/user-attachments/assets/972cc703-12f6-40ac-91c4-02dd06bbdc04)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
