### PR TITLE
Fix: 다른 Wrapper에 잘못적용한 width 속성 수정

### DIFF
--- a/client/src/features/test/TestInformSection.tsx
+++ b/client/src/features/test/TestInformSection.tsx
@@ -46,7 +46,6 @@ const InfoBlock = styled.div`
   gap: 28px; // 제목과 아래 요소 간격
   padding-top: 20px;
   padding-bottom: 10px;
-  max-width: 850px;
 `;
 
 // 검사 진행방법, 설명 텍스트, 샘플 묶음
@@ -71,7 +70,7 @@ const SampleWrapper = styled.div`
 `;
 
 const TextWrapper = styled.div`
-  width: 100%;
+  width: 850px;
   padding: 0 1rem;
   box-sizing: border-box;
 `;


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 다른 Wrapper에 잘못적용한 width 속성 수정

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- TestInform 텍스트 줄바꿈이 강제로 적용될 수 있도록 width를 %로 변경했습니다.
- 이전 브랜치에 commit했는데 그전에 merge 되어버려서 다시 씁니다...
- 근데 사실 반응형으로 다시 수정하다보면 의미없는 작업인 거 같기는 합니다 ㅎㅎ..

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 가치관 검사 소개 문장의 줄바꿈이 쉼표에서 잘 넘어가는지

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![image](https://github.com/user-attachments/assets/99a466b6-088c-4628-b30c-159caf99a79a)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
