### PR TITLE
Design: 메인페이지 메세지섹션 반응형 구현

### DIFF
--- a/client/src/components/StepItem.tsx
+++ b/client/src/components/StepItem.tsx
@@ -10,12 +10,14 @@ const Container = styled.div`
 `;
 
 const Number = styled.div<{ active: boolean }>`
-  font-size: 4rem;
+  font-size: 4rem; // ✅ 기존 유지
   font-weight: 700;
   color: ${({ active }) => (active ? '#5668FF' : '#A0A3FF')};
   margin-right: 1rem;
   transition: color 0.3s;
+
   @media (max-width: 768px) {
+    font-size: 2.2rem; // ✅ 모바일에서만 작게
     margin-right: 0;
   }
 `;
@@ -31,14 +33,17 @@ const Label = styled.div<{ active: boolean }>`
   display: flex;
   min-width: 300px;
   max-width: 400px;
-  font-size: 3rem;
+  font-size: 3rem; // ✅ 기존 유지
   font-weight: 500;
   opacity: ${({ active }) => (active ? 1 : 0.5)};
   transition:
     background-color 0.3s,
     color 0.3s,
     opacity 0.3s;
+
   @media (max-width: 768px) {
+    font-size: 1.6rem; // ✅ 모바일에서만 작게
+    min-width: 200px;
     margin-left: 0;
     text-align: center;
   }

--- a/client/src/features/main/DividerSection.tsx
+++ b/client/src/features/main/DividerSection.tsx
@@ -5,7 +5,9 @@ const Divider = styled.div`
   background: linear-gradient(to bottom, #ffffff 0%, ${({ theme }) => theme.colors.white} 100%);
   width: 100%;
 
-
+  @media (max-width: 768px) {
+    height: 15vh;
+  }
   }
 `;
 

--- a/client/src/features/main/FlowButtonSection.tsx
+++ b/client/src/features/main/FlowButtonSection.tsx
@@ -39,9 +39,14 @@ const StepWrapper = styled.div`
   padding-left: 20vw;
   left: 0;
 
+  @media (max-width: 1024px) {
+    padding-left: 10vw;
+  }
+
   @media (max-width: 768px) {
     padding-left: 0;
     align-items: center;
+    gap: 1.5rem;
   }
 `;
 

--- a/client/src/features/main/MessageSection.tsx
+++ b/client/src/features/main/MessageSection.tsx
@@ -9,49 +9,93 @@ import iconStar from '../../assets/icons/icon-star.png';
 import iconMoon from '../../assets/icons/icon-moon.png';
 import lyingBear from '../../assets/lying-bear.png';
 
-// ======================= styled components =======================
 const NextSection = styled.section`
   width: 100vw;
-  height: auto;
   background: linear-gradient(to bottom, #000000 0%, #4f63ff 50%, #ffffff 100%);
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 2;
+  padding: clamp(40px, 6vw, 100px) 0;
+`;
+
+const ResponsiveBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(30px, 5vw, 60px);
+  width: 100%;
 `;
 
 const WordWrap = styled.div`
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   justify-content: center;
   align-items: center;
-  flex-wrap: wrap;
+  padding: 0 5vw;
+  text-align: center;
+
+  span {
+    font-size: clamp(1.6rem, 6vw, 3.75rem);
+    font-weight: 700;
+  }
 `;
 
-// ======================= animation variants =======================
-const fadeInVariants: Variants = {
-  hidden: { opacity: 0, y: 50 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.6, ease: 'easeOut' } },
-};
+const Row = styled(motion.div)<{ align?: 'left' | 'right' }>`
+  width: 100%;
+  display: flex;
+  justify-content: ${({ align }) =>
+    align === 'left' ? 'flex-start' : align === 'right' ? 'flex-end' : 'center'};
+  padding: 0 10vw;
 
-const wordVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: (i: number) => ({
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.6,
-      delay: i * 0.25,
-    },
-  }),
-};
+  @media (max-width: 768px) {
+    padding: 0 6vw;
+  }
+`;
 
-// ======================= component =======================
+const TextRow = styled(motion.div)<{ align?: 'left' | 'right' }>`
+  width: 100%;
+  display: flex;
+  justify-content: ${({ align }) =>
+    align === 'left' ? 'flex-start' : align === 'right' ? 'flex-end' : 'center'};
+  padding: 0 10vw;
+
+  @media (max-width: 1100px) {
+    padding: 0 6vw;
+    justify-content: center;
+  }
+`;
+
+const MobileTextWrapper = styled.div<{ align?: 'left' | 'right' }>`
+  display: inline-block;
+  white-space: nowrap;
+  text-align: ${({ align }) => align || 'left'};
+
+  @media (max-width: 1100px) {
+    transform: scale(0.85);
+    transform-origin: center;
+    text-align: center;
+  }
+`;
+
+const FinalSection = styled(motion.div)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 30px;
+  margin-top: 40px;
+
+  @media (max-width: 768px) {
+    gap: 16px;
+    margin-top: 20px;
+  }
+`;
+
 export default function MessageSection() {
   const theme = useTheme();
 
-  // 요소별 애니메이션 제어
   const scroll = useScrollAnimation();
   const star = useScrollAnimation();
   const text1 = useScrollAnimation();
@@ -63,107 +107,93 @@ export default function MessageSection() {
 
   return (
     <NextSection>
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '40px' }}>
-        {/* 1. 스크롤 아이콘 */}
+      <ResponsiveBox>
         <motion.div
           ref={scroll.ref}
           initial="hidden"
           animate={scroll.controls}
           variants={fadeInVariants}
         >
-          <Image src={iconScroll} alt="스크롤 아이콘" width="80px" motion="float" />
+          <Image
+            src={iconScroll}
+            alt="스크롤 아이콘"
+            width="clamp(40px, 10vw, 80px)"
+            motion="float"
+          />
         </motion.div>
 
-        {/* 2. 별 아이콘 */}
-        <motion.div
+        <Row
           ref={star.ref}
           initial="hidden"
           animate={star.controls}
           variants={fadeInVariants}
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            margin: '40px 0',
-            marginRight: '35%',
-            width: '100vw',
-          }}
+          align="right"
         >
-          <Image src={iconStar} alt="별 아이콘" width="100px" motion="float" />
-        </motion.div>
+          <Image src={iconStar} alt="별 아이콘" width="clamp(50px, 12vw, 100px)" motion="float" />
+        </Row>
 
-        {/* 3. 문장 1 */}
-        <motion.div
+        <TextRow
           ref={text1.ref}
           initial="hidden"
           animate={text1.controls}
           variants={fadeInVariants}
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-start',
-            margin: '40px 0',
-            marginLeft: '35%',
-            width: '100vw',
-          }}
+          align="left"
         >
-          <Text as="h2" size="60px" weight="bold" color="white" align="left">
-            하고 싶은 일을 몰라도 괜찮아요
-          </Text>
-        </motion.div>
+          <MobileTextWrapper>
+            <Text
+              as="h2"
+              size="clamp(1.3rem, 6vw, 3.75rem)"
+              weight="bold"
+              color="white"
+              align="left"
+            >
+              하고 싶은 일을 몰라도 괜찮아요
+            </Text>
+          </MobileTextWrapper>
+        </TextRow>
 
-        {/* 4. 문장 2 */}
-        <motion.div
+        <TextRow
           ref={text2.ref}
           initial="hidden"
           animate={text2.controls}
           variants={fadeInVariants}
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            margin: '40px 0',
-            marginRight: '25%',
-            width: '100vw',
-          }}
+          align="right"
         >
-          <Text as="h2" size="60px" weight="bold" color="white" align="right">
-            우리는 당신에게 맞는 길부터 찾으니까요
-          </Text>
-        </motion.div>
+          <MobileTextWrapper>
+            <Text
+              as="h2"
+              size="clamp(1.3rem, 6vw, 3.75rem)"
+              weight="bold"
+              color="white"
+              align="right"
+            >
+              우리는 당신에게 맞는 길부터 찾으니까요
+            </Text>
+          </MobileTextWrapper>
+        </TextRow>
 
-        {/* 5. 달 아이콘 */}
-        <motion.div
+        <Row
           ref={moon.ref}
           initial="hidden"
           animate={moon.controls}
           variants={fadeInVariants}
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-start',
-            margin: '40px 0',
-            marginTop: '-10px',
-            marginLeft: '30%',
-            width: '100vw',
-          }}
+          align="left"
         >
-          <Image src={iconMoon} alt="달 아이콘" width="110px" motion="float" />
-        </motion.div>
+          <Image src={iconMoon} alt="달 아이콘" width="clamp(60px, 14vw, 110px)" motion="float" />
+        </Row>
 
-        {/* 6. 누운 곰 + 최종 문장 */}
-        <motion.div
+        <FinalSection
           ref={bear.ref}
           initial="hidden"
           animate={bear.controls}
           variants={fadeInVariants}
-          style={{
-            textAlign: 'center',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            flexDirection: 'column',
-          }}
         >
-          <Image src={lyingBear} alt="누워있는 곰" width="450px" motion="float" />
-
-          {/* 마지막 문장 - 단어별 애니메이션 */}
+          <Image
+            src={lyingBear}
+            alt="누워있는 곰"
+            width="clamp(200px, 40vw, 450px)"
+            motion="float"
+          />
           <WordWrap>
             {words.map((word, i) => (
               <motion.span
@@ -173,7 +203,6 @@ export default function MessageSection() {
                 whileInView="visible"
                 variants={wordVariants}
                 viewport={{ once: false, amount: 0.5 }}
-                style={{ fontSize: '60px', fontWeight: 700, color: theme.colors.gray900 }}
               >
                 {i === 0 ? (
                   <>
@@ -185,8 +214,30 @@ export default function MessageSection() {
               </motion.span>
             ))}
           </WordWrap>
-        </motion.div>
-      </div>
+        </FinalSection>
+      </ResponsiveBox>
     </NextSection>
   );
 }
+
+// ============ animation variants ============
+const fadeInVariants: Variants = {
+  hidden: { opacity: 0, y: 50 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: 'easeOut' },
+  },
+};
+
+const wordVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.4,
+      delay: i * 0.15,
+    },
+  }),
+};

--- a/client/src/features/main/MessageSection.tsx
+++ b/client/src/features/main/MessageSection.tsx
@@ -24,8 +24,15 @@ const ResponsiveBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(30px, 5vw, 60px);
   width: 100%;
+`;
+
+const SectionGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(30px, 5vw, 60px);
+  padding: clamp(85px, 6vw, 80px) 0;
 `;
 
 const WordWrap = styled.div`
@@ -108,81 +115,89 @@ export default function MessageSection() {
   return (
     <NextSection>
       <ResponsiveBox>
-        <motion.div
-          ref={scroll.ref}
-          initial="hidden"
-          animate={scroll.controls}
-          variants={fadeInVariants}
-        >
-          <Image
-            src={iconScroll}
-            alt="스크롤 아이콘"
-            width="clamp(40px, 10vw, 80px)"
-            motion="float"
-          />
-        </motion.div>
+        {/* 스크롤 아이콘 영역 */}
+        <SectionGroup>
+          <motion.div
+            ref={scroll.ref}
+            initial="hidden"
+            animate={scroll.controls}
+            variants={fadeInVariants}
+          >
+            <Image
+              src={iconScroll}
+              alt="스크롤 아이콘"
+              width="clamp(40px, 10vw, 80px)"
+              motion="float"
+            />
+          </motion.div>
+        </SectionGroup>
 
-        <Row
-          ref={star.ref}
-          initial="hidden"
-          animate={star.controls}
-          variants={fadeInVariants}
-          align="right"
-        >
-          <Image src={iconStar} alt="별 아이콘" width="clamp(50px, 12vw, 100px)" motion="float" />
-        </Row>
+        {/* 별/문장/달 아이콘 영역 */}
+        <SectionGroup>
+          <Row
+            ref={star.ref}
+            initial="hidden"
+            animate={star.controls}
+            variants={fadeInVariants}
+            align="right"
+          >
+            <Image src={iconStar} alt="별 아이콘" width="clamp(50px, 12vw, 100px)" motion="float" />
+          </Row>
 
-        <TextRow
-          ref={text1.ref}
-          initial="hidden"
-          animate={text1.controls}
-          variants={fadeInVariants}
-          align="left"
-        >
-          <MobileTextWrapper>
-            <Text
-              as="h2"
-              size="clamp(1.3rem, 6vw, 3.75rem)"
-              weight="bold"
-              color="white"
-              align="left"
-            >
-              하고 싶은 일을 몰라도 괜찮아요
-            </Text>
-          </MobileTextWrapper>
-        </TextRow>
+          <TextRow
+            ref={text1.ref}
+            initial="hidden"
+            animate={text1.controls}
+            variants={fadeInVariants}
+            align="left"
+          >
+            <MobileTextWrapper>
+              <Text
+                as="h2"
+                size="clamp(1.3rem, 6vw, 3.75rem)"
+                weight="bold"
+                color="white"
+                align="left"
+              >
+                하고 싶은 일을 몰라도 괜찮아요
+              </Text>
+            </MobileTextWrapper>
+          </TextRow>
 
-        <TextRow
-          ref={text2.ref}
-          initial="hidden"
-          animate={text2.controls}
-          variants={fadeInVariants}
-          align="right"
-        >
-          <MobileTextWrapper>
-            <Text
-              as="h2"
-              size="clamp(1.3rem, 6vw, 3.75rem)"
-              weight="bold"
-              color="white"
-              align="right"
-            >
-              우리는 당신에게 맞는 길부터 찾으니까요
-            </Text>
-          </MobileTextWrapper>
-        </TextRow>
+          <TextRow
+            ref={text2.ref}
+            initial="hidden"
+            animate={text2.controls}
+            variants={fadeInVariants}
+            align="right"
+          >
+            <MobileTextWrapper>
+              <Text
+                as="h2"
+                size="clamp(1.3rem, 6vw, 3.75rem)"
+                weight="bold"
+                color="white"
+                align="right"
+              >
+                우리는 당신에게 맞는 길부터 찾으니까요
+              </Text>
+            </MobileTextWrapper>
+          </TextRow>
 
-        <Row
-          ref={moon.ref}
-          initial="hidden"
-          animate={moon.controls}
-          variants={fadeInVariants}
-          align="left"
-        >
-          <Image src={iconMoon} alt="달 아이콘" width="clamp(60px, 14vw, 110px)" motion="float" />
-        </Row>
+          <Row
+            ref={moon.ref}
+            initial="hidden"
+            animate={moon.controls}
+            variants={fadeInVariants}
+            align="left"
+          >
+            <Image src={iconMoon} alt="달 아이콘" width="clamp(60px, 14vw, 110px)" motion="float" />
+          </Row>
+        </SectionGroup>
 
-        <FinalSection
+        {/* 누워있는 곰 영역 */}
+        <SectionGroup
+          as={FinalSection}
           ref={bear.ref}
           initial="hidden"
           animate={bear.controls}
@@ -214,7 +229,7 @@ export default function MessageSection() {
               </motion.span>
             ))}
           </WordWrap>
-        </FinalSection>
+        </SectionGroup>
       </ResponsiveBox>
     </NextSection>
   );

--- a/client/src/features/main/TitleSection.tsx
+++ b/client/src/features/main/TitleSection.tsx
@@ -30,7 +30,7 @@ const Bear = styled(motion.img)`
   top: 20%;
   left: 60%;
   transform: translate(-50%, -50%);
-  width: clamp(180px, 33vw, 500px);
+  width: clamp(160px, 33vw, 500px);
   pointer-events: none;
 
   @media (max-width: 768px) {
@@ -49,7 +49,7 @@ const TextGroup = styled(motion.div)`
 
   @media (max-width: 768px) {
     top: 20vh;
-    left: 10vw;
+    left: 15vw;
     gap: 1.5rem;
   }
 `;
@@ -143,7 +143,7 @@ export default function TitleSection() {
           <motion.div variants={textVariants} custom={1}>
             <Text
               as="h1"
-              size="clamp(2.8rem, 8vw, 7.5rem)"
+              size="clamp(2.5rem, 8vw, 7.5rem)"
               weight="bold"
               color="primary"
               align="left"

--- a/client/src/features/test/TestQuestionSection.tsx
+++ b/client/src/features/test/TestQuestionSection.tsx
@@ -108,6 +108,30 @@ export default function TestQuestionSection({
     }, 300);
   };
 
+  // ✅ 키보드 이벤트 처리
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!questions[currentIndex] || clicked || animating) return;
+
+      const { answer01: left, answer02: right } = questions[currentIndex];
+
+      switch (e.key) {
+        case 'ArrowLeft':
+          setSelected(left);
+          break;
+        case 'ArrowRight':
+          setSelected(right);
+          break;
+        case 'Enter':
+          if (selected) handleNext();
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selected, questions, currentIndex, clicked, animating]);
+
   // Back 버튼 중복 클릭 방지용 핸들러
   const handleBack = () => {
     if (clicked || animating) return;


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 메인페이지의 MessageSection 모바일뷰를 고려하여 반응형 구현했습니다.
2. 세로로 긴 화면에 맞추어 각 영역 사이의 gap을 추가했습니다.
3. 메인페이지의 FlowButtonSection의 StepItem의 크기를 반응형으로 수정했습니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- x

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 각자의 모니터에서 잘 나오는지 . . . 

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![Animation7](https://github.com/user-attachments/assets/89648440-3026-4f57-a11c-de7b2a794592)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
