### PR TITLE
Fix: 서버 캐싱 누락 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .cache
+report-cache.json
 
 # Editor directories and files
 .vscode/*

--- a/server/index.js
+++ b/server/index.js
@@ -26,12 +26,9 @@ app.use(
   })
 );
 
-// 메모리 캐시 (기본 6시간 TTL)
-const cache = new NodeCache({ stdTTL: 60 * 60 * 6 });
-
 // 라우트 등록
 app.get('/questions', getQuestionsHandler);
-app.post('/report', (req, res) => getReportHandler(req, res, cache));
+app.post('/report', (req, res) => getReportHandler(req, res));
 
 app.listen(PORT, () => {
   console.log(`✅  서버 실행: http://localhost:${PORT}`);

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -1,5 +1,8 @@
 import { requestCareerResultUrl } from '../services/careerAPI.js';
 import getChartDataFromReportUrl from '../services/puppeteer.js';
+import { loadCacheFromFile, saveCacheToFile } from '../utils/cacheStore.js';
+
+let persistentCache = loadCacheFromFile();
 
 export const getReportHandler = async (req, res, cache) => {
   const { answers } = req.body;
@@ -8,11 +11,10 @@ export const getReportHandler = async (req, res, cache) => {
     return res.status(400).json({ error: 'answers 값이 필요합니다.' });
   }
 
-  // 1. 캐시 확인
-  const cached = cache.get(answers);
-  if (cached) {
-    console.log('📦 캐시된 데이터 반환');
-    return res.json(cached);
+  // 캐시 체크
+  if (persistentCache[answers]) {
+    console.log('📦 디스크 캐시 반환');
+    return res.json(persistentCache[answers]);
   }
 
   try {
@@ -27,8 +29,9 @@ export const getReportHandler = async (req, res, cache) => {
       results: reportData,
     };
 
-    // 4. 캐시에 저장
-    cache.set(answers, responseData);
+    // 캐시에 저장 + 파일로 저장
+    persistentCache[answers] = responseData;
+    saveCacheToFile(persistentCache);
 
     // 5. 클라이언트에 결과 전송
     return res.json(responseData);

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -4,7 +4,7 @@ import { loadCacheFromFile, saveCacheToFile } from '../utils/cacheStore.js';
 
 let persistentCache = loadCacheFromFile();
 
-export const getReportHandler = async (req, res, cache) => {
+export const getReportHandler = async (req, res) => {
   const { answers } = req.body;
 
   if (!answers) {

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -1,25 +1,37 @@
 import { requestCareerResultUrl } from '../services/careerAPI.js';
 import getChartDataFromReportUrl from '../services/puppeteer.js';
 
-export const getReportHandler = async (req, res) => {
+export const getReportHandler = async (req, res, cache) => {
   const { answers } = req.body;
 
   if (!answers) {
     return res.status(400).json({ error: 'answers 값이 필요합니다.' });
   }
 
+  // 1. 캐시 확인
+  const cached = cache.get(answers);
+  if (cached) {
+    console.log('📦 캐시된 데이터 반환');
+    return res.json(cached);
+  }
+
   try {
-    // 1. 결과 URL 생성
+    // 2. 결과 URL 생성
     const resultUrl = await requestCareerResultUrl(answers);
 
-    // 2. Puppeteer로 실제 결과 크롤링
+    // 3. Puppeteer로 실제 결과 크롤링
     const reportData = await getChartDataFromReportUrl(resultUrl);
 
-    // 3. 클라이언트에 결과 전송
-    return res.json({
+    const responseData = {
       url: resultUrl,
       results: reportData,
-    });
+    };
+
+    // 4. 캐시에 저장
+    cache.set(answers, responseData);
+
+    // 5. 클라이언트에 결과 전송
+    return res.json(responseData);
   } catch (error) {
     console.error('❌ 결과 생성 실패:', error.message);
     return res.status(500).json({ error: '결과 처리 중 오류' });

--- a/server/utils/cacheStore.js
+++ b/server/utils/cacheStore.js
@@ -1,0 +1,19 @@
+// utils/cacheStore.js
+import fs from 'fs';
+import path from 'path';
+
+const CACHE_PATH = path.join(process.cwd(), 'report-cache.json');
+
+// 캐시 로딩
+export const loadCacheFromFile = () => {
+  if (fs.existsSync(CACHE_PATH)) {
+    const raw = fs.readFileSync(CACHE_PATH, 'utf-8');
+    return JSON.parse(raw);
+  }
+  return {};
+};
+
+// 캐시 저장
+export const saveCacheToFile = (cache) => {
+  fs.writeFileSync(CACHE_PATH, JSON.stringify(cache, null, 2));
+};


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 응답을 key값으로, 결과를 json화 하여 캐싱합니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 기존에는 메모리에 cache를 들고있어 다시 시작하면 날아갔지만, 이제는 json파일에 관리합니다.

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 추후 json파일이 응답이 많아지면 커질 수 있지만,  수백개 정도는 큰 문제가 없을듯 하여 json 파일로 직접 저장하였습니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

### 캐싱 전
![좀걸려이](https://github.com/user-attachments/assets/95d2e1d7-3760-4fb0-a68b-6ac8c39cca8c)

### 캐싱 후
![바로받아와](https://github.com/user-attachments/assets/61406574-932b-48ac-9131-fe11a7519352)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
