### PR TITLE
Refactor: 메인페이지 메세지섹션 리팩토링

### DIFF
--- a/client/src/features/main/MessageSection.tsx
+++ b/client/src/features/main/MessageSection.tsx
@@ -32,13 +32,13 @@ const SectionGroup = styled.div`
   flex-direction: column;
   align-items: center;
   gap: clamp(30px, 5vw, 60px);
-  padding: clamp(85px, 6vw, 80px) 0;
+  padding: clamp(100px, 6vw, 80px) 0;
 `;
 
 const WordWrap = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
   justify-content: center;
   align-items: center;
   padding: 0 5vw;
@@ -55,29 +55,40 @@ const Row = styled(motion.div)<{ align?: 'left' | 'right' }>`
   display: flex;
   justify-content: ${({ align }) =>
     align === 'left' ? 'flex-start' : align === 'right' ? 'flex-end' : 'center'};
-  padding: 0 10vw;
+  padding: ${({ align }) => {
+    if (align === 'right') return '0 0 0 10vw';
+    if (align === 'left') return '0 10vw 0 0';
+    return '0 10vw';
+  }};
 
   @media (max-width: 768px) {
     padding: 0 6vw;
   }
 `;
 
-const TextRow = styled(motion.div)<{ align?: 'left' | 'right' }>`
+const TextRow = styled(motion.div)<{ align?: 'left' | 'right'; isSecond?: boolean }>`
   width: 100%;
   display: flex;
   justify-content: ${({ align }) =>
     align === 'left' ? 'flex-start' : align === 'right' ? 'flex-end' : 'center'};
   padding: 0 10vw;
 
+  @media (min-width: 1100px) {
+    ${({ isSecond }) => (isSecond ? 'margin-right: -70px;' : 'margin-left: -300px;')}
+  }
+
   @media (max-width: 1100px) {
     padding: 0 6vw;
     justify-content: center;
+    margin: 0;
+    text-align: center;
   }
 `;
 
 const MobileTextWrapper = styled.div<{ align?: 'left' | 'right' }>`
   display: inline-block;
   white-space: nowrap;
+  width: 100%;
   text-align: ${({ align }) => align || 'left'};
 
   @media (max-width: 1100px) {
@@ -95,8 +106,8 @@ const FinalSection = styled(motion.div)`
   margin-top: 40px;
 
   @media (max-width: 768px) {
-    gap: 16px;
-    margin-top: 20px;
+    gap: 1px;
+    margin-top: 40px;
   }
 `;
 
@@ -151,13 +162,13 @@ export default function MessageSection() {
             variants={fadeInVariants}
             align="left"
           >
-            <MobileTextWrapper>
+            <MobileTextWrapper align="left">
               <Text
                 as="h2"
                 size="clamp(1.3rem, 6vw, 3.75rem)"
                 weight="bold"
                 color="white"
-                align="left"
+                align="center"
               >
                 하고 싶은 일을 몰라도 괜찮아요
               </Text>
@@ -170,14 +181,15 @@ export default function MessageSection() {
             animate={text2.controls}
             variants={fadeInVariants}
             align="right"
+            isSecond
           >
-            <MobileTextWrapper>
+            <MobileTextWrapper align="right">
               <Text
                 as="h2"
                 size="clamp(1.3rem, 6vw, 3.75rem)"
                 weight="bold"
                 color="white"
-                align="right"
+                align="center"
               >
                 우리는 당신에게 맞는 길부터 찾으니까요
               </Text>
@@ -206,7 +218,7 @@ export default function MessageSection() {
           <Image
             src={lyingBear}
             alt="누워있는 곰"
-            width="clamp(200px, 40vw, 450px)"
+            width="clamp(240px, 40vw, 450px)"
             motion="float"
           />
           <WordWrap>

--- a/client/src/features/main/MessageSection.tsx
+++ b/client/src/features/main/MessageSection.tsx
@@ -32,7 +32,7 @@ const SectionGroup = styled.div`
   flex-direction: column;
   align-items: center;
   gap: clamp(30px, 5vw, 60px);
-  padding: clamp(100px, 6vw, 80px) 0;
+  padding: clamp(85px, 6vw, 80px) 0;
 `;
 
 const WordWrap = styled.div`
@@ -55,11 +55,8 @@ const Row = styled(motion.div)<{ align?: 'left' | 'right' }>`
   display: flex;
   justify-content: ${({ align }) =>
     align === 'left' ? 'flex-start' : align === 'right' ? 'flex-end' : 'center'};
-  padding: ${({ align }) => {
-    if (align === 'right') return '0 0 0 10vw';
-    if (align === 'left') return '0 10vw 0 0';
-    return '0 10vw';
-  }};
+  padding: ${({ align }) =>
+    align === 'right' ? '0 0 0 10vw' : align === 'left' ? '0 10vw 0 0' : '0 10vw'};
 
   @media (max-width: 768px) {
     padding: 0 6vw;
@@ -74,7 +71,8 @@ const TextRow = styled(motion.div)<{ align?: 'left' | 'right'; isSecond?: boolea
   padding: 0 10vw;
 
   @media (min-width: 1100px) {
-    ${({ isSecond }) => (isSecond ? 'margin-right: -70px;' : 'margin-left: -300px;')}
+    margin-right: ${({ isSecond }) => (isSecond ? '-70px' : '0')};
+    margin-left: ${({ isSecond }) => (isSecond ? '0' : '-300px')};
   }
 
   @media (max-width: 1100px) {
@@ -106,8 +104,8 @@ const FinalSection = styled(motion.div)`
   margin-top: 40px;
 
   @media (max-width: 768px) {
-    gap: 1px;
-    margin-top: 40px;
+    gap: 16px;
+    margin-top: 20px;
   }
 `;
 
@@ -126,7 +124,6 @@ export default function MessageSection() {
   return (
     <NextSection>
       <ResponsiveBox>
-        {/* 스크롤 아이콘 영역 */}
         <SectionGroup>
           <motion.div
             ref={scroll.ref}
@@ -143,7 +140,6 @@ export default function MessageSection() {
           </motion.div>
         </SectionGroup>
 
-        {/* 별/문장/달 아이콘 영역 */}
         <SectionGroup>
           <Row
             ref={star.ref}
@@ -207,7 +203,6 @@ export default function MessageSection() {
           </Row>
         </SectionGroup>
 
-        {/* 누워있는 곰 영역 */}
         <SectionGroup
           as={FinalSection}
           ref={bear.ref}
@@ -218,7 +213,7 @@ export default function MessageSection() {
           <Image
             src={lyingBear}
             alt="누워있는 곰"
-            width="clamp(240px, 40vw, 450px)"
+            width="clamp(200px, 40vw, 450px)"
             motion="float"
           />
           <WordWrap>
@@ -247,7 +242,6 @@ export default function MessageSection() {
   );
 }
 
-// ============ animation variants ============
 const fadeInVariants: Variants = {
   hidden: { opacity: 0, y: 50 },
   visible: {

--- a/client/src/features/main/MessageSection.tsx
+++ b/client/src/features/main/MessageSection.tsx
@@ -71,8 +71,8 @@ const TextRow = styled(motion.div)<{ align?: 'left' | 'right'; isSecond?: boolea
   padding: 0 10vw;
 
   @media (min-width: 1100px) {
-    margin-right: ${({ isSecond }) => (isSecond ? '-70px' : '0')};
-    margin-left: ${({ isSecond }) => (isSecond ? '0' : '-300px')};
+    margin-right: ${({ isSecond }) => (isSecond ? '-15%' : '0')};
+    margin-left: ${({ isSecond }) => (isSecond ? '0' : '-32%')};
   }
 
   @media (max-width: 1100px) {


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 반응형으로 변경한 후, 어색해졌던 레이아웃을 다시 피그마대로 다듬었습니다.
2. 다듬으면서 지저분해진 코드를 좀 더 명확하게 리팩토링했습니다.

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 좌측으로 정렬되던 텍스트를 풀화면에서는 피그마UI대로 보일 수 있도록 변경했습니다. 이후 화면이 작아지면 중앙 정렬로 변경됩니다.
- px로 고정되어있던 margin을 어느 화면에서나 비슷한 느낌의 UI로 보이도록 유동적으로 변경했습니다.
- 다듬으면서 지저분해진 코드를 명확하게 리팩토링 했습니다.
- TextRow 내부의 margin 조건을 보다 명시적이고 안정적으로 작성
- Row 패딩 처리도 align에 따라 간결하게 조건 설정
- 전체 구조/의미는 유지하면서 불필요한 중복 스타일 제거

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 최종이기를.......ㅜㅜ

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
